### PR TITLE
GISAID covCLI bugfixes & BioSample/SRA modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ docker-compose-*.yaml
 
 # ignore folders
 **/.Rproj.user
+**/test_data/*
+**/gisaid_cli/*

--- a/argument_handler.py
+++ b/argument_handler.py
@@ -72,7 +72,7 @@ def args_parser():
 		required=True)
 	file_parser.add_argument("--fasta_file",
 		help="Fasta file used to generate submission files; fasta header should match the column 'sequence_name' stored in your metadata. Input either full file path or if just file name it must be stored at '<submission_dir>/<submission_name>/<fasta_file>'.",
-		required=True)
+		default = None)
 	file_parser.add_argument("--table2asn",
 		help="Perform a table2asn submission instead of GenBank FTP submission for organism choices 'FLU' or 'COV'.",
 		required=False,

--- a/biosample_sra_handler.py
+++ b/biosample_sra_handler.py
@@ -58,7 +58,8 @@ def create_manual_submission_files(database: str, submission_dir: str, metadata:
 		column_ordered = ["sample_name","library_ID"]
 		prefix = "sra-"
 		# Create SRA specific fields
-		metadata["sra-title"] = config_dict["Description"]["Title"]
+		if 'sra-title' not in metadata.columns or (metadata['sra-title'].fillna('') == '').any(): 
+			metadata["sra-title"] = config_dict["Description"]["Title"]
 		filename_cols = [col for col in metadata.columns.tolist() if re.match("sra-file_[1-9]\d*", col)]
 		# Correct index for filename column
 		for col in filename_cols:

--- a/biosample_sra_handler.py
+++ b/biosample_sra_handler.py
@@ -58,7 +58,7 @@ def create_manual_submission_files(database: str, submission_dir: str, metadata:
 		column_ordered = ["sample_name","library_ID"]
 		prefix = "sra-"
 		# Create SRA specific fields
-		if 'sra-title' not in metadata.columns or (metadata['sra-title'].fillna('') == '').any(): 
+		if 'sra-title' not in metadata.columns or metadata['sra-title'].isnull().any() or (metadata['sra-title'] == '').any():
 			metadata["sra-title"] = config_dict["Description"]["Title"]
 		filename_cols = [col for col in metadata.columns.tolist() if re.match("sra-file_[1-9]\d*", col)]
 		# Correct index for filename column

--- a/biosample_sra_handler.py
+++ b/biosample_sra_handler.py
@@ -143,8 +143,10 @@ def create_submission_xml(organism: str, database: str, submission_name: str, co
 			# Remove columns with bs-prefix that are not attributes
 			biosample_cols = [col for col in database_df.columns.tolist() if (col.startswith('bs-')) and (col not in ["bs-sample_name", "bs-package", "bs-description"])]
 			for col in biosample_cols:
-				attribute = etree.SubElement(attributes, "Attribute", attribute_name=col.replace("bs-",""))
-				attribute.text = row[col]
+				attribute_value = row[col]
+				if pd.notnull(attribute_value) and attribute_value.strip() != "":
+					attribute = etree.SubElement(attributes, "Attribute", attribute_name=col.replace("bs-",""))
+					attribute.text = row[col]
 			# Add collection date to Attributes
 			attribute = etree.SubElement(attributes, "Attribute", attribute_name="collection_date")
 			attribute.text = row["collection_date"]
@@ -177,8 +179,10 @@ def create_submission_xml(organism: str, database: str, submission_name: str, co
 			# Remove columns with sra- prefix that are not attributes
 			sra_cols = [col for col in database_df.columns.tolist() if col.startswith('sra-') and not re.match("(sra-sample_name|sra-file_location|sra-file_\d*)", col)]
 			for col in sra_cols:
-				attribute = etree.SubElement(addfiles, "Attribute", name=col.replace("sra-",""))
-				attribute.text = row[col]
+				attribute_value = row[col]
+				if pd.notnull(attribute_value) and attribute_value.strip() != "":
+					attribute = etree.SubElement(addfiles, "Attribute", name=col.replace("sra-",""))
+					attribute.text = row[col]
 			if pd.notnull(row["bioproject"]) and row["bioproject"].strip() != "":
 				attribute_ref_id = etree.SubElement(addfiles, "AttributeRefId", name="BioProject")
 				refid = etree.SubElement(attribute_ref_id, "RefId")

--- a/gisaid_handler.py
+++ b/gisaid_handler.py
@@ -16,7 +16,6 @@ from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 import re
-import json
 
 import upload_log
 import tools
@@ -76,7 +75,6 @@ def process_gisaid_log(log_file: str, submission_dir: str) -> pd.DataFrame:
 	with open(log_file, "r") as file:
 		line = file.readline().strip()
 		while line:
-			line2 = json.loads(line)
 			# If accession generated record it
 			# Pattern options: "msg:": "<Sample Name>; <EPI_ISL/EPI_ID>_<Accession Numbers>" OR <epi_isl_id/epi_id>: <Sample Name>; <EPI_ISL/EPI_ID>_<Accession Numbers>
 			# Changed re.match to re.search to return tokens that aren't at the beginning. Changed the regex to capture an arbitrary amount of numbers after EPI_

--- a/ncbi_handler.py
+++ b/ncbi_handler.py
@@ -127,9 +127,6 @@ def submit_ncbi(database: str, submission_name: str, submission_dir: str, config
 	tools.check_credentials(config_dict=config_dict, database="NCBI")
 	# Submit sequences to NCBI via FTP Server
 	print(f"Uploading sample files to NCBI-{database}, as a '{submission_type}' submission. If this is not intended, interrupt immediately.", file=sys.stdout)
-	if submission_type != "TEST":
-		print("Error: submission_type " + str(submission_type))
-		sys.exit(1)
 	time.sleep(5)
 	try:
 		# Login into NCBI FTP Server

--- a/seqsender.py
+++ b/seqsender.py
@@ -25,6 +25,8 @@ import tools
 
 from settings import VERSION
 
+import sys
+
 # Define current time
 STARTTIME = datetime.now()
 

--- a/seqsender.py
+++ b/seqsender.py
@@ -62,6 +62,9 @@ def prep(database: List[str], organism: str, submission_dir: str, submission_nam
 			file_dict[file_type] = updated_path # type: ignore
 	# load config file
 	config_dict = tools.get_config(config_file=file_dict["config_file"], database=database)
+	# warn if user is submitting biosample & sra together with Link_Sample_Between_NCBI_Databases off
+	if not config_dict["NCBI"]["Link_Sample_Between_NCBI_Databases"] and 'SRA' in database and 'BIOSAMPLE' in database:
+		print("Warning: You are submitting to BioSample and SRA together, but Link_Sample_Between_NCBI_Databases is off. If you did not intend to do this, SRA submission is likely to fail.\nIf this was unintentional, cancel the submission and set 'Link_Sample_Between_NCBI_Databases: on' in your config yaml.")
 	# load metadata file
 	metadata = tools.get_metadata(database=database, organism=organism, metadata_file=file_dict["metadata_file"], config_dict=config_dict, skip_validation=skip_validation)
 	# Load fasta file into metadata

--- a/settings.py
+++ b/settings.py
@@ -54,12 +54,14 @@ SRA_REGEX = "^sra-|^bioproject$|^organism$|^collection_date$"
 # Genbank metadata regex
 GENBANK_REGEX = "^gb-sample_name$"
 
+# Also added sequence_name to these Genbank entries since I needed it for GISAID, but haven't tested the GenBank workflow yet
 # GenBank source file metadata regex
-GENBANK_REGEX_SRC = "^gb-sample_name$|^src-|^bioproject$|^organism$|^collection_date$"
+GENBANK_REGEX_SRC = "^sequence_name$|^gb-sample_name$|^src-|^bioproject$|^organism$|^collection_date$"
 
 # GenBank comment file metadata regex
-GENBANK_REGEX_CMT = "^gb-sample_name$|^cmt-|^organism$|^collection_date$"
+GENBANK_REGEX_CMT = "^sequence_name$|^gb-sample_name$|^cmt-|^organism$|^collection_date$"
 
 ##### GISAID settings #####
 # GISAID metadata regex
-GISAID_REGEX = "^gs-|^collection_date$|^authors"
+# Added ^sequence_name$ here - it seemed to be getting filtered out too early and causing issues
+GISAID_REGEX = "^gs-|^sequence_name$|^collection_date$|^authors$"

--- a/tools.py
+++ b/tools.py
@@ -14,6 +14,7 @@ from pandera import Check
 from datetime import datetime, timedelta
 from cerberus import Validator
 import re
+import shutil
 
 from config.seqsender.seqsender_schema import schema as seqsender_schema
 from settings import SCHEMA_EXCLUSIONS, BIOSAMPLE_REGEX, SRA_REGEX, GISAID_REGEX, GENBANK_REGEX, GENBANK_REGEX_CMT, GENBANK_REGEX_SRC
@@ -132,6 +133,17 @@ def parse_hold_date(config_dict: Dict[str, Any]):
 def get_metadata(database: List[str], organism: str, metadata_file: str, config_dict: Dict[str, Any], skip_validation: bool = False) -> pd.DataFrame:
 	# Read in metadata file
 	metadata = file_handler.load_csv(metadata_file)
+	# Adding some default handling for bs-description here - it's not mandatory for biosample submission, but is required in the workflow
+	if 'bs-description' not in metadata.columns:
+	# Create 'bs-description' by joining 'organism', 'bs-host', and 'bs-host_disease' columns
+		metadata['bs-description'] = metadata[['organism', 'bs-host', 'bs-host_disease']].apply(
+		lambda row: ' '.join(row.dropna().astype(str)), axis=1
+	)
+	# If there are empty biosample or sra columns in the metadata sheet, assume they are unused optional columns and drop them before pandera attempts to validate
+	columns_to_drop = [col for col in metadata.columns if (col.startswith('bs-') or col.startswith('sra-')) and metadata[col].replace('', pd.NA).apply(lambda x: x.strip() if isinstance(x, str) else x).isna().all()]
+	metadata = metadata.drop(columns=columns_to_drop)
+	shutil.copy(metadata_file, metadata_file + ".bak")
+	file_handler.save_csv(metadata, metadata_file)
 	# Update seqsender base schema to include needed checks
 	if "BioSample" in database or "SRA" in database:
 		seqsender_schema.update_columns({"bioproject":{"checks":Check.str_matches(r"^(?!\s*$).+"),"nullable":False,"required":True}})

--- a/tools.py
+++ b/tools.py
@@ -134,11 +134,12 @@ def get_metadata(database: List[str], organism: str, metadata_file: str, config_
 	# Read in metadata file
 	metadata = file_handler.load_csv(metadata_file)
 	# Adding some default handling for bs-description here - it's not mandatory for biosample submission, but is required in the workflow
-	if 'bs-description' not in metadata.columns:
-	# Create 'bs-description' by joining 'organism', 'bs-host', and 'bs-host_disease' columns
-		metadata['bs-description'] = metadata[['organism', 'bs-host', 'bs-host_disease']].apply(
-		lambda row: ' '.join(row.dropna().astype(str)), axis=1
-	)
+	if "BIOSAMPLE" in database:
+		if 'bs-description' not in metadata.columns:
+		# Create 'bs-description' by joining 'organism', 'bs-host', and 'bs-host_disease' columns
+			metadata['bs-description'] = metadata[['organism', 'bs-host', 'bs-host_disease']].apply(
+			lambda row: ' '.join(row.dropna().astype(str)), axis=1
+		)
 	# If there are empty biosample or sra columns in the metadata sheet, assume they are unused optional columns and drop them before pandera attempts to validate
 	columns_to_drop = [col for col in metadata.columns if (col.startswith('bs-') or col.startswith('sra-')) and metadata[col].replace('', pd.NA).apply(lambda x: x.strip() if isinstance(x, str) else x).isna().all()]
 	if columns_to_drop:
@@ -146,7 +147,7 @@ def get_metadata(database: List[str], organism: str, metadata_file: str, config_
 		shutil.copy(metadata_file, metadata_file + ".bak")
 		file_handler.save_csv(metadata, metadata_file)
 	# Update seqsender base schema to include needed checks
-	if "BioSample" in database or "SRA" in database:
+	if "BIOSAMPLE" in database or "SRA" in database:
 		seqsender_schema.update_columns({"bioproject":{"checks":Check.str_matches(r"^(?!\s*$).+"),"nullable":False,"required":True}})
 	biosample_schema = sra_schema = genbank_schema = genbank_cmt_schema = genbank_src_schema = gisaid_schema = None
 	# Import schemas

--- a/tools.py
+++ b/tools.py
@@ -141,9 +141,10 @@ def get_metadata(database: List[str], organism: str, metadata_file: str, config_
 	)
 	# If there are empty biosample or sra columns in the metadata sheet, assume they are unused optional columns and drop them before pandera attempts to validate
 	columns_to_drop = [col for col in metadata.columns if (col.startswith('bs-') or col.startswith('sra-')) and metadata[col].replace('', pd.NA).apply(lambda x: x.strip() if isinstance(x, str) else x).isna().all()]
-	metadata = metadata.drop(columns=columns_to_drop)
-	shutil.copy(metadata_file, metadata_file + ".bak")
-	file_handler.save_csv(metadata, metadata_file)
+	if columns_to_drop:
+		metadata = metadata.drop(columns=columns_to_drop)
+		shutil.copy(metadata_file, metadata_file + ".bak")
+		file_handler.save_csv(metadata, metadata_file)
 	# Update seqsender base schema to include needed checks
 	if "BioSample" in database or "SRA" in database:
 		seqsender_schema.update_columns({"bioproject":{"checks":Check.str_matches(r"^(?!\s*$).+"),"nullable":False,"required":True}})

--- a/upload_log.py
+++ b/upload_log.py
@@ -87,7 +87,10 @@ def validate_submission_status_df(metadata: pd.DataFrame, database: List[str]) -
 		sys.exit(1)
 
 # Update values of existing submission_status.csv file
-def update_submission_status_csv(submission_dir: str, update_database: str, update_df: pd.DataFrame):
+def update_submission_status_csv(submission_dir: str, update_database: str, update_df: pd.DataFrame, update_count: dict = {}):
+	# track changes to update_df
+	if update_database not in update_count:
+		update_count[update_database] = 0
 	# Pop off directory if inside database directory
 	if os.path.split(submission_dir)[1] in ["BIOSAMPLE", "SRA", "GENBANK", "GISAID"]:
 		submission_dir = os.path.split(submission_dir)[0]
@@ -99,17 +102,31 @@ def update_submission_status_csv(submission_dir: str, update_database: str, upda
 	validate_submission_status_df(metadata=df, database=all_databases)
 	if f"{SAMPLE_NAME_DATABASE_PREFIX[update_database]}sample_name" in update_df:
 		sample_column = (SAMPLE_NAME_DATABASE_PREFIX[update_database] + "sample_name")
+		df = df.set_index(sample_column, drop = False)
+		update_df = update_df.set_index(sample_column)
+		df.update(update_df)
+		df = df.reset_index(drop = True)
+		update_count[update_database] += 1
+		validate_submission_status_df(metadata=df, database=all_databases)
+		file_handler.save_csv(df=df, file_path=submission_status_file)
 	elif f"{SAMPLE_NAME_DATABASE_PREFIX[update_database]}segment_name" in update_df:
 		sample_column = (SAMPLE_NAME_DATABASE_PREFIX[update_database] + "segment_name")
+		df = df.set_index(sample_column, drop = False)
+		update_df = update_df.set_index(sample_column)
+		df.update(update_df)
+		df = df.reset_index(drop = True)
+		update_count[update_database] += 1
+		validate_submission_status_df(metadata=df, database=all_databases)
+		file_handler.save_csv(df=df, file_path=submission_status_file)
 	else:
-		print(f"Error: Unable to update 'submission_status.csv' for '{update_database}' at '{submission_dir}'.", file=sys.stderr)
-		sys.exit(1)
-	df = df.set_index(sample_column, drop = False)
-	update_df = update_df.set_index(sample_column)
-	df.update(update_df)
-	df = df.reset_index(drop = True)
-	validate_submission_status_df(metadata=df, database=all_databases)
-	file_handler.save_csv(df=df, file_path=submission_status_file)
+		# No longer exits when unable to update since there may be valid reasons update_df is empty (submission w/only isolates or only segments).
+		# Alerts the user until this function performs at least one successful update during a submission workflow.
+		# Also changed the behavior of process_gisaid_log so that situation ideally shouldn't come up much
+		if update_count[update_database] == 0:
+			print(f"Error: Unable to update 'submission_status.csv' for '{update_database}' at '{submission_dir}'. The log file may be empty.", file=sys.stderr)
+			# sys.exit(1)
+
+	return update_count
 
 # Create new row in submission_log.csv for database submission
 def create_submission_log(database: str, organism: str, submission_name: str, submission_dir: str, database_dir: str, config_file: str, submission_status: str, submission_id: str, submission_type: str) -> None:
@@ -134,7 +151,20 @@ def create_submission_log(database: str, organism: str, submission_name: str, su
 	df.loc[len(df)] = new_entry # type: ignore
 	# Remove duplicates and keep latest update
 	df = df.drop_duplicates(subset = ["Submission_Name", "Organism", "Database", "Submission_Type", "Config_File"], keep = "last", ignore_index = True)
-	file_handler.save_csv(df=df, file_path=submission_dir, file_name="submission_log.csv")
+	# Ran into permissions issues writing this to submission_dir - all the other outputs wrote successfully to submission_dir/submission_files and submission_dir/submission_files/GISAID
+	# Probably really uncommon, but this handles that error and tries to output submission info to stdout instead - might just add perms check for the entire submission directory tree
+	try:
+		file_handler.save_csv(df=df, file_path=submission_dir, file_name="submission_log.csv")
+		print(f"Successfully updated submission_log.csv at '{submission_dir}'.")
+	except PermissionError as e:
+		print(f"Permission error: Unable to write to 'submission_log.csv' at '{submission_dir}'. Please check file and directory permissions.", file=sys.stderr)
+		print(f"Attempting to write submission log to stdout instead.")
+		df.to_csv(sys.stdout, header=True, index=False)
+		sys.exit(1)
+	except Exception as e:
+		print(f"An unexpected error occurred while trying to save 'submission_log.csv': {e}", file=sys.stderr)
+		sys.exit(1)
+	#file_handler.save_csv(df=df, file_path=submission_dir, file_name="submission_log.csv")
 
 # Update values of existing submission_log.csv file
 def update_submission_log(database: str, organism: str, submission_name: str, submission_log_dir: str, submission_dir: str, submission_status: str, submission_id: str, submission_type: str) -> None:


### PR DESCRIPTION
**Edit: added some BioSample/SRA workflow changes and attached my config.yaml and metadata files in case you wanted to test against them.**
[example_config.yaml.txt](https://github.com/user-attachments/files/16646673/example_config.yaml.txt)
[example_metadata.csv](https://github.com/user-attachments/files/16770321/example_metadata.csv)


Hey Dakota! Thanks for getting this new release out. The new handling for BioSample packages is amazing. I hugely appreciate how much this project simplifies metadata validation across multiple pathogens/packages/repositories and how convenient it makes large volume submissions.

~~I've tested the BioSample/SRA, and GISAID covCLI workflows - the NCBI workflows worked perfectly, but I ran into a bunch of submission failures testing covCLI.~~


~~I made some modifications and now my GISAID submissions are going through reliably. I haven't had time to do any serious testing so I can't say if all these changes will hold up, but I wanted to go ahead and submit a pull request in case there's anything that might be helpful.~~

The former description of this pull request is a little out of date now. I've been testing GISAID covCLI, SRA, and BioSample heavily, using the SARS-CoV-2 and OneHealth Enteric BioSample packages. Below are changes addressing workflow errors/submission failures I encountered during testing. I want to revisit a few of the changes I made, but hopefully some of them are useful! 

## ⚙️ General

- Remove code blocking prod submissions
- Make fasta file an optional input

## 🛠️ covCLI updates/bugfixes

- Modify several interactions w/the metadata sheet column headers
- Adjust logfile parsing to properly capture the sample name and EPI ID from the submission log
- Address issues causing some functions to exit prematurely when passed empty inputs (when only GISAID isolates or GISAID segments are present)
- Prevent crashing when submission includes samples already registered in GISAID - warn the user & log virus name and EPI ID
_Edit: this is working as far as preventing crashes, but isn't reliably logging the EPI ID of the repeated samples_

## 📋 BioSample & SRA updates/bugfixes
- Drop empty bs- & sra- columns before metadata validation. Pandera will ignore optional columns if they don't exist - if they exist but have no data pandera will attempt to validate them and the workflow will fail. If a mandatory column has been left empty by the user and is removed by this change, pandera will still catch it.
- If bs-description is absent, create it by joining values from `organism`, `bs-host`, `bs-host_disease`. `bs-description` isn't in the Submission Wizard template and is not required by NCBI for submission, but the workflow will fail when it isn't present.
_Edit: I want to revisit this, because it doesn't seem like missing bs-description causes a crash w/every BioSample package, and also this is kind of a bandaid anyway._
- Warn the user if performing BioSample and SRA submissions together with `Link_Sample_Between_NCBI_Databases` disabled. SRA submission is likely to fail in this situation unless the user has added BioSample accessions manually beforehand.
- Prevent workflow from failing if bs-description is missing when user is not submitting to BioSample.
- When a biosample/sra column has mixture of data & blank rows, don't write the blank attributes to submission.xml. This causes the affected sample to fail, & there are a couple of valid reasons to have mixed columns:
  - submitting multiple pathogens under the same biosample template w/different optional fields completed
  - submitting mix of paired and single end reads to SRA


Testing data was generated via:
```
python seqsender.py test_data --biosample --sra --gisaid --organism COV --submission_dir test_data/CCPHL/
```
Metadata and config templates were created with the Shiny app Submission Wizard

And the workflow was run with this command:
```
python seqsender.py submit --biosample --sra --gisaid --organism COV --submission_dir test_data/CCPHL/ --submission_name COV_TEST_DATA --config_file test_data/CCPHL/cov_ccphl_config.yaml --metadata_file test_data/CCPHL/meta2.csv --fasta_file test_data/CCPHL/sequence.fasta --test
```

